### PR TITLE
Ignore common k8s kubeconfig users, clusters, & contexts

### DIFF
--- a/internal/kubecfg/apply.go
+++ b/internal/kubecfg/apply.go
@@ -1,0 +1,88 @@
+package kubecfg
+
+import (
+	"bytes"
+
+	"github.com/BigPapaChas/gogok8s/internal/terminal"
+	"k8s.io/client-go/tools/clientcmd/api"
+	v1 "k8s.io/client-go/tools/clientcmd/api/v1"
+)
+
+func applyClusterChanges(config *api.Config, cluster *v1.NamedCluster) {
+	compareClusterChanges(config, cluster)
+
+	if _, ok := config.Clusters[cluster.Name]; !ok {
+		config.Clusters[cluster.Name] = &api.Cluster{
+			Server:                   cluster.Cluster.Server,
+			CertificateAuthorityData: cluster.Cluster.CertificateAuthorityData,
+		}
+	} else {
+		config.Clusters[cluster.Name].Server = cluster.Cluster.Server
+		config.Clusters[cluster.Name].CertificateAuthorityData = cluster.Cluster.CertificateAuthorityData
+	}
+}
+
+func applyUserChanges(config *api.Config, user *v1.NamedAuthInfo) {
+	if _, ok := config.AuthInfos[user.Name]; !ok {
+		config.AuthInfos[user.Name] = &api.AuthInfo{
+			Exec: &api.ExecConfig{
+				Command:    user.AuthInfo.Exec.Command,
+				Args:       user.AuthInfo.Exec.Args,
+				Env:        convertExecEnvVar(user.AuthInfo.Exec.Env),
+				APIVersion: user.AuthInfo.Exec.APIVersion,
+			},
+		}
+	} else {
+		config.AuthInfos[user.Name].Exec.Command = user.AuthInfo.Exec.Command
+		config.AuthInfos[user.Name].Exec.Args = user.AuthInfo.Exec.Args
+		config.AuthInfos[user.Name].Exec.Env = convertExecEnvVar(user.AuthInfo.Exec.Env)
+		config.AuthInfos[user.Name].Exec.APIVersion = user.AuthInfo.Exec.APIVersion
+	}
+}
+
+func applyContextChanges(config *api.Config, context *v1.NamedContext) {
+	if _, ok := config.Contexts[context.Name]; !ok {
+		config.Contexts[context.Name] = &api.Context{
+			Cluster:  context.Context.Cluster,
+			AuthInfo: context.Context.AuthInfo,
+		}
+	} else {
+		config.Contexts[context.Name].Cluster = context.Context.Cluster
+		config.Contexts[context.Name].AuthInfo = context.Context.AuthInfo
+	}
+}
+
+func compareClusterChanges(config *api.Config, cluster *v1.NamedCluster) bool {
+	if currentConfig, ok := config.Clusters[cluster.Name]; !ok {
+		terminal.DiffAdd(cluster.Name)
+
+		return true
+	} else if currentConfig.Server != cluster.Cluster.Server ||
+		!bytes.Equal(currentConfig.CertificateAuthorityData, cluster.Cluster.CertificateAuthorityData) {
+		terminal.DiffModify(cluster.Name)
+		if currentConfig.Server != cluster.Cluster.Server {
+			terminal.DiffMinus(currentConfig.Server)
+			terminal.DiffAdd(cluster.Cluster.Server)
+		}
+		if !bytes.Equal(currentConfig.CertificateAuthorityData, cluster.Cluster.CertificateAuthorityData) {
+			terminal.DiffMinus("certificate-authority-data: <OMITTED>")
+			terminal.DiffAdd("certificate-authority-data: <OMITTED>")
+		}
+
+		return true
+	}
+
+	return false
+}
+
+func convertExecEnvVar(envVars []v1.ExecEnvVar) []api.ExecEnvVar {
+	var convertedExecEnvVars []api.ExecEnvVar
+	for _, envVar := range envVars {
+		convertedExecEnvVars = append(convertedExecEnvVars, api.ExecEnvVar{
+			Name:  envVar.Name,
+			Value: envVar.Value,
+		})
+	}
+
+	return convertedExecEnvVars
+}

--- a/internal/kubecfg/kubecfg.go
+++ b/internal/kubecfg/kubecfg.go
@@ -1,7 +1,6 @@
 package kubecfg
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -34,7 +33,7 @@ func LoadFromFile(filename string) (*api.Config, error) {
 	if err != nil && errors.Is(err, os.ErrNotExist) {
 		return api.NewConfig(), nil
 	} else if err != nil {
-		return nil, fmt.Errorf("failed to load kube config from file: %w", err)
+		return nil, fmt.Errorf("failed to load kubeconfig from file: %w", err)
 	}
 
 	return cfg, nil
@@ -47,7 +46,7 @@ func Write(config *api.Config) error {
 	}
 
 	if err = clientcmd.WriteToFile(*config, filename); err != nil {
-		return fmt.Errorf("failed to write kube config to file: %w", err)
+		return fmt.Errorf("failed to write kubeconfig to file: %w", err)
 	}
 
 	return nil
@@ -75,152 +74,6 @@ func ApplyPatch(patch *KubeConfigPatch, config *api.Config, purge bool) {
 	if purge {
 		purgeKubeConfig(patch, config)
 	}
-}
-
-func purgeKubeConfig(patch *KubeConfigPatch, config *api.Config) {
-	// purge clusters
-	purgeClusters(patch, config)
-	// purge users
-	purgeUsers(patch, config)
-	// purge contexts
-	purgeContexts(patch, config)
-}
-
-func purgeContexts(patch *KubeConfigPatch, config *api.Config) {
-	existingContexts := make(map[string]struct{})
-	for _, context := range patch.Contexts {
-		existingContexts[context.Name] = struct{}{}
-	}
-
-	var contextsToDelete []string
-
-	for name := range config.Contexts {
-		if _, ok := existingContexts[name]; !ok {
-			contextsToDelete = append(contextsToDelete, name)
-		}
-	}
-
-	for _, context := range contextsToDelete {
-		delete(config.Contexts, context)
-	}
-}
-
-func purgeUsers(patch *KubeConfigPatch, config *api.Config) {
-	existingUsers := make(map[string]struct{})
-	for _, user := range patch.Users {
-		existingUsers[user.Name] = struct{}{}
-	}
-
-	var usersToDelete []string
-
-	for name := range config.AuthInfos {
-		if _, ok := existingUsers[name]; !ok {
-			usersToDelete = append(usersToDelete, name)
-		}
-	}
-
-	for _, user := range usersToDelete {
-		delete(config.AuthInfos, user)
-	}
-}
-
-func purgeClusters(patch *KubeConfigPatch, config *api.Config) {
-	existingClusters := make(map[string]struct{})
-	for _, cluster := range patch.Clusters {
-		existingClusters[cluster.Name] = struct{}{}
-	}
-
-	var clustersToDelete []string
-
-	for name := range config.Clusters {
-		if _, ok := existingClusters[name]; !ok {
-			terminal.DiffMinus(name)
-			clustersToDelete = append(clustersToDelete, name)
-		}
-	}
-
-	for _, cluster := range clustersToDelete {
-		delete(config.Clusters, cluster)
-	}
-}
-
-func applyClusterChanges(config *api.Config, cluster *v1.NamedCluster) {
-	compareClusterChanges(config, cluster)
-
-	if _, ok := config.Clusters[cluster.Name]; !ok {
-		config.Clusters[cluster.Name] = &api.Cluster{
-			Server:                   cluster.Cluster.Server,
-			CertificateAuthorityData: cluster.Cluster.CertificateAuthorityData,
-		}
-	} else {
-		config.Clusters[cluster.Name].Server = cluster.Cluster.Server
-		config.Clusters[cluster.Name].CertificateAuthorityData = cluster.Cluster.CertificateAuthorityData
-	}
-}
-
-func applyUserChanges(config *api.Config, user *v1.NamedAuthInfo) {
-	if _, ok := config.AuthInfos[user.Name]; !ok {
-		config.AuthInfos[user.Name] = &api.AuthInfo{
-			Exec: &api.ExecConfig{
-				Command:    user.AuthInfo.Exec.Command,
-				Args:       user.AuthInfo.Exec.Args,
-				Env:        convertExecEnvVar(user.AuthInfo.Exec.Env),
-				APIVersion: user.AuthInfo.Exec.APIVersion,
-			},
-		}
-	} else {
-		config.AuthInfos[user.Name].Exec.Command = user.AuthInfo.Exec.Command
-		config.AuthInfos[user.Name].Exec.Args = user.AuthInfo.Exec.Args
-		config.AuthInfos[user.Name].Exec.Env = convertExecEnvVar(user.AuthInfo.Exec.Env)
-		config.AuthInfos[user.Name].Exec.APIVersion = user.AuthInfo.Exec.APIVersion
-	}
-}
-
-func applyContextChanges(config *api.Config, context *v1.NamedContext) {
-	if _, ok := config.Contexts[context.Name]; !ok {
-		config.Contexts[context.Name] = &api.Context{
-			Cluster:  context.Context.Cluster,
-			AuthInfo: context.Context.AuthInfo,
-		}
-	} else {
-		config.Contexts[context.Name].Cluster = context.Context.Cluster
-		config.Contexts[context.Name].AuthInfo = context.Context.AuthInfo
-	}
-}
-
-func compareClusterChanges(config *api.Config, cluster *v1.NamedCluster) bool {
-	if currentConfig, ok := config.Clusters[cluster.Name]; !ok {
-		terminal.DiffAdd(cluster.Name)
-
-		return true
-	} else if currentConfig.Server != cluster.Cluster.Server ||
-		!bytes.Equal(currentConfig.CertificateAuthorityData, cluster.Cluster.CertificateAuthorityData) {
-		terminal.DiffModify(cluster.Name)
-		if currentConfig.Server != cluster.Cluster.Server {
-			terminal.DiffMinus(currentConfig.Server)
-			terminal.DiffAdd(cluster.Cluster.Server)
-		}
-		if !bytes.Equal(currentConfig.CertificateAuthorityData, cluster.Cluster.CertificateAuthorityData) {
-			terminal.DiffMinus("certificate-authority-data: <OMITTED>")
-			terminal.DiffAdd("certificate-authority-data: <OMITTED>")
-		}
-
-		return true
-	}
-
-	return false
-}
-
-func convertExecEnvVar(envVars []v1.ExecEnvVar) []api.ExecEnvVar {
-	var convertedExecEnvVars []api.ExecEnvVar
-	for _, envVar := range envVars {
-		convertedExecEnvVars = append(convertedExecEnvVars, api.ExecEnvVar{
-			Name:  envVar.Name,
-			Value: envVar.Value,
-		})
-	}
-
-	return convertedExecEnvVars
 }
 
 func getKubeConfigFilePath() (string, error) {

--- a/internal/kubecfg/purge.go
+++ b/internal/kubecfg/purge.go
@@ -1,0 +1,109 @@
+package kubecfg
+
+import (
+	"github.com/BigPapaChas/gogok8s/internal/terminal"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// The default clusters to ignore when purging a user's kubeconfig.
+//nolint:gochecknoglobals
+var defaultIgnoredClusters = map[string]struct{}{
+	"docker-desktop":   {},
+	"minikube":         {},
+	"microk8s-cluster": {},
+}
+
+// The default users to ignore when purging a user's kubeconfig.
+//nolint:gochecknoglobals
+var defaultIgnoredUsers = map[string]struct{}{
+	"docker-desktop": {},
+	"minikube":       {},
+	"admin":          {}, // used by microk8s
+}
+
+// The default contexts to ignore when purging a user's kubeconfig.
+//nolint:gochecknoglobals
+var defaultIgnoredContexts = map[string]struct{}{
+	"docker-desktop": {},
+	"minikube":       {},
+	"microk8s":       {},
+}
+
+func purgeKubeConfig(patch *KubeConfigPatch, config *api.Config) {
+	purgeClusters(patch, config)
+	purgeUsers(patch, config)
+	purgeContexts(patch, config)
+}
+
+func purgeClusters(patch *KubeConfigPatch, config *api.Config) {
+	existingClusters := make(map[string]struct{})
+	for _, cluster := range patch.Clusters {
+		existingClusters[cluster.Name] = struct{}{}
+	}
+
+	var clustersToDelete []string
+
+	for name := range config.Clusters {
+		// Skip clusters ignored by default
+		if _, ok := defaultIgnoredClusters[name]; ok {
+			continue
+		}
+
+		if _, ok := existingClusters[name]; !ok {
+			terminal.DiffMinus(name)
+			clustersToDelete = append(clustersToDelete, name)
+		}
+	}
+
+	for _, cluster := range clustersToDelete {
+		delete(config.Clusters, cluster)
+	}
+}
+
+func purgeUsers(patch *KubeConfigPatch, config *api.Config) {
+	existingUsers := make(map[string]struct{})
+	for _, user := range patch.Users {
+		existingUsers[user.Name] = struct{}{}
+	}
+
+	var usersToDelete []string
+
+	for name := range config.AuthInfos {
+		// Skip users ignored by default
+		if _, ok := defaultIgnoredUsers[name]; ok {
+			continue
+		}
+
+		if _, ok := existingUsers[name]; !ok {
+			usersToDelete = append(usersToDelete, name)
+		}
+	}
+
+	for _, user := range usersToDelete {
+		delete(config.AuthInfos, user)
+	}
+}
+
+func purgeContexts(patch *KubeConfigPatch, config *api.Config) {
+	existingContexts := make(map[string]struct{})
+	for _, context := range patch.Contexts {
+		existingContexts[context.Name] = struct{}{}
+	}
+
+	var contextsToDelete []string
+
+	for name := range config.Contexts {
+		// Skip contexts ignored by default
+		if _, ok := defaultIgnoredContexts[name]; ok {
+			continue
+		}
+
+		if _, ok := existingContexts[name]; !ok {
+			contextsToDelete = append(contextsToDelete, name)
+		}
+	}
+
+	for _, context := range contextsToDelete {
+		delete(config.Contexts, context)
+	}
+}


### PR DESCRIPTION
# Summary
- Ignore the contexts, users, and clusters created by common local k8s provisioning tools (docker-desktop, microk8s, minikube)
- Separate out `kubecfg.go` into more apt-named files