### PR TITLE
Use go version 1.21.3 for release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: 1.21
+          goversion: 1.21.3
           project_path: "./cmd/gogok8s"
           binary_name: "gogok8s"
           extra_files: LICENSE README.md


### PR DESCRIPTION
# Summary
- Use `go` version `1.21.3` when running the release Github Action