### PR TITLE
Fix nil kube config patch

### DIFF
--- a/internal/clusters/eks.go
+++ b/internal/clusters/eks.go
@@ -63,15 +63,15 @@ const (
 )
 
 func (a EKSAccount) GenerateKubeConfig() (*kubecfg.KubeConfigPatch, []error) {
+	accountKubeConfig := &kubecfg.KubeConfigPatch{}
+
 	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithSharedConfigProfile(a.Profile))
 	if err != nil {
-		return nil, []error{err}
+		return accountKubeConfig, []error{err}
 	}
 
 	client := eks.NewFromConfig(cfg)
 	clusters, errors := a.ScanForClusters(client)
-
-	accountKubeConfig := &kubecfg.KubeConfigPatch{}
 
 	for _, cluster := range clusters {
 		patch := a.generateKubeConfigFromCluster(cluster)
@@ -87,7 +87,7 @@ func (a EKSAccount) PrettyName() string {
 	return a.Name
 }
 
-func (a *EKSAccount) generateKubeConfigFromCluster(cluster EKSClusterConfig) *kubecfg.KubeConfigPatch {
+func (a EKSAccount) generateKubeConfigFromCluster(cluster EKSClusterConfig) *kubecfg.KubeConfigPatch {
 	patch := &kubecfg.KubeConfigPatch{}
 
 	var clusterName, userName, contextName string
@@ -146,7 +146,7 @@ func (a *EKSAccount) generateKubeConfigFromCluster(cluster EKSClusterConfig) *ku
 	return patch
 }
 
-func (a *EKSAccount) ScanForClusters(client EKSClusterAPI) ([]EKSClusterConfig, []error) {
+func (a EKSAccount) ScanForClusters(client EKSClusterAPI) ([]EKSClusterConfig, []error) {
 	ch := make(chan scanForClustersResult, len(a.Regions))
 
 	for _, region := range a.Regions {

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -27,7 +27,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:     "gogok8s",
 	Short:   "gogok8s helps manage your k8s cluster kubeconfig(s)",
-	Version: "v1.2.0",
+	Version: "v1.2.1",
 }
 
 //nolint:gochecknoinits


### PR DESCRIPTION
# Summary
- Return an empty kubeconfig patch instead of `nil` if there are errors fetching the AWS profile configuration