### PR TITLE
feat: support separate cluster access and discovery profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ accounts:
       - eu-west-1
     format: "${name}.${clusterArn}"
   - name: Prod
-    profile: prod-admin-readonly
+    profile: prod-admin
+    scanProfile: prod-readonly
     regions:
       - us-east-1
       - us-east-2
@@ -57,7 +58,9 @@ accounts:
 
 Each entry in `accounts` can have the following fields:
 - `name` - A convenient name you wish to give for this AWS account
-- `profile` - The AWS profile name used to list & describe EKS clusters
+- `profile` - The AWS profile name to use for the kubeconfig context
+- `scanProfile` - Optional AWS profile name used for listing/describing EKS clusters (if cluster discovery and access
+permissions are separate). Same as `profile` by default.
 - `regions` - The list of AWS regions that will be searched for EKS clusters
 - `format` - The format of the kubeconfig contexts, users, and clusters. By default, all kubeconfig resources will be
 named `${name}.${region}.${clusterName}`. For example, if the `Dev` account within the config file above had a cluster

--- a/internal/clusters/eks.go
+++ b/internal/clusters/eks.go
@@ -14,11 +14,12 @@ import (
 )
 
 type EKSAccount struct {
-	Profile    string    `yaml:"profile"`
-	Regions    []string  `yaml:"regions"`
-	Name       string    `yaml:"name"`
-	Format     string    `yaml:"format"`
-	ExtraUsers []EKSUser `yaml:"extraUsers,omitempty"`
+	Profile     string    `yaml:"profile"`
+	ScanProfile string    `yaml:"scanProfile,omitempty"`
+	Regions     []string  `yaml:"regions"`
+	Name        string    `yaml:"name"`
+	Format      string    `yaml:"format"`
+	ExtraUsers  []EKSUser `yaml:"extraUsers,omitempty"`
 }
 
 type EKSUser struct {
@@ -65,7 +66,12 @@ const (
 func (a EKSAccount) GenerateKubeConfig() (*kubecfg.KubeConfigPatch, []error) {
 	accountKubeConfig := &kubecfg.KubeConfigPatch{}
 
-	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithSharedConfigProfile(a.Profile))
+	scanProfile := a.ScanProfile
+	if scanProfile == "" {
+		scanProfile = a.Profile
+	}
+
+	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithSharedConfigProfile(scanProfile))
 	if err != nil {
 		return accountKubeConfig, []error{err}
 	}

--- a/internal/commands/configure.go
+++ b/internal/commands/configure.go
@@ -67,15 +67,21 @@ var configCmd = &cobra.Command{
 			return fmt.Errorf("failed to select AWS profile: %w", err)
 		}
 
+		scanProfile, err := terminal.PromptDefault("AWS Profile for cluster discovery, if different", "")
+		if err != nil {
+			return fmt.Errorf("failed to select AWS profile for cluster discovery: %w", err)
+		}
+
 		regions, err := terminal.MultiSelect("AWS regions", config.ValidRegions)
 		if err != nil {
 			return fmt.Errorf("failed to select AWS regions: %w", err)
 		}
 
 		account := clusters.EKSAccount{
-			Profile: profile,
-			Regions: regions,
-			Name:    accountName,
+			Profile:     profile,
+			ScanProfile: scanProfile,
+			Regions:     regions,
+			Name:        accountName,
 		}
 		cfg.AddAccount(account)
 


### PR DESCRIPTION
The `profile` field is used for two things: discovering clusters, and as the `AWS_PROFILE` in the kubeconfig user. However, it is not necessarily the case that the profile one uses for accessing a cluster is one that also has permission to list clusters, and vice versa; a readonly account role might not have access to the clusters themselves. Allow distinguishing these two uses of `profile` by introducing an optional separate `scanProfile` field.